### PR TITLE
Changed /users endpoints responses

### DIFF
--- a/upsolver-api/routes/users.js
+++ b/upsolver-api/routes/users.js
@@ -57,7 +57,7 @@ router.post(
     );
     await user.update({ token });
 
-    res.status(201).json(user);
+    res.status(201).json({ user });
   })
 );
 
@@ -88,7 +88,7 @@ router.post(
 
     await user.update({ token });
 
-    res.status(200).json(user);
+    res.status(200).json({ user });
   })
 );
 

--- a/upsolver-ui/src/components/LoginForm/LoginForm.jsx
+++ b/upsolver-ui/src/components/LoginForm/LoginForm.jsx
@@ -21,9 +21,9 @@ export default function LoginForm() {
         body: JSON.stringify({ username, password }),
         credentials: "include",
       });
-      const user = await response.json();
-      if (user.username) {
-        updateUser(user);
+      const data = await response.json();
+      if (data.user) {
+        updateUser(data.user);
         navigate("/teams/my");
       } else {
         alert("[!] Login failed");

--- a/upsolver-ui/src/components/SignupForm/SignupForm.jsx
+++ b/upsolver-ui/src/components/SignupForm/SignupForm.jsx
@@ -26,8 +26,8 @@ export default function SignupForm() {
         credentials: "include",
       });
       const data = await response.json();
-      if (data.username) {
-        updateUser(data);
+      if (data.user) {
+        updateUser(data.user);
         navigate("/teams/my");
       } else {
         alert("[!] Signup failed");


### PR DESCRIPTION
## Description

- I modified the object returned by user endpoints and adapted the front end to receive the new response type.

## Milestones
- N/A.

## Resources
- N/A.

## Test Plan
- It is still possible to login correctly and the application obtains the information of the active user: <img width="1728" alt="Captura de pantalla 2023-07-13 a la(s) 9 49 57 p m" src="https://github.com/cdamezcua/Upsolver/assets/88699709/1405fd59-4ad8-4dde-b14b-100ec35dcdce">
