### PR TITLE
New screens for team's groups, and team's members

### DIFF
--- a/upsolver-ui/src/components/App/App.jsx
+++ b/upsolver-ui/src/components/App/App.jsx
@@ -8,6 +8,8 @@ import { Container } from "@mui/material";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import ProtectedRoute from "../ProtectedRoute/ProtectedRoute.jsx";
 import TeamsScreen from "../TeamsScreen/TeamsScreen";
+import GroupsScreen from "../GroupsScreen/GroupsScreen";
+import MembersScreen from "../MembersScreen/MembersScreen";
 
 export default function App() {
   const [user, setUser] = useState(() => {
@@ -52,7 +54,7 @@ export default function App() {
     <div className="App">
       <UserContext.Provider value={{ user, updateUser }}>
         <BrowserRouter>
-          <Routes basename="/">
+          <Routes>
             <Route
               path="/"
               element={
@@ -60,10 +62,6 @@ export default function App() {
                   element={<Navigate to="/teams/my" replace={true} />}
                 />
               }
-            />
-            <Route
-              path="/teams/my"
-              element={<ProtectedRoute element={<TeamsScreen />} />}
             />
             <Route
               path="login"
@@ -86,6 +84,18 @@ export default function App() {
                   <SignupForm />
                 </Container>
               }
+            />
+            <Route
+              path="/teams/my"
+              element={<ProtectedRoute element={<TeamsScreen />} />}
+            />
+            <Route
+              path="/team/:teamId/groups"
+              element={<ProtectedRoute element={<GroupsScreen />} />}
+            />
+            <Route
+              path="/team/:teamId/members"
+              element={<ProtectedRoute element={<MembersScreen />} />}
             />
           </Routes>
         </BrowserRouter>

--- a/upsolver-ui/src/components/GroupsScreen/GroupsScreen.css
+++ b/upsolver-ui/src/components/GroupsScreen/GroupsScreen.css
@@ -1,0 +1,5 @@
+.page-button .button-link {
+    text-decoration: none;
+    color: inherit;
+  }
+  

--- a/upsolver-ui/src/components/GroupsScreen/GroupsScreen.jsx
+++ b/upsolver-ui/src/components/GroupsScreen/GroupsScreen.jsx
@@ -1,0 +1,147 @@
+import React from "react";
+import "./GroupsScreen.css";
+import Navbar from "../Navbar/Navbar";
+import { Box, Divider, Typography } from "@mui/material";
+import { Button, Stack } from "@mui/material";
+import { Link } from "react-router-dom";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from "@mui/material";
+import { UserContext } from "../../UserContext.js";
+import { useEffect, useContext } from "react";
+
+function createData(name, calories, fat, carbs, protein) {
+  return { name, calories, fat, carbs, protein };
+}
+
+const rows = [
+  createData("Frozen yoghurt", 159, 6.0, 24, 4.0),
+  createData("Ice cream sandwich", 237, 9.0, 37, 4.3),
+  createData("Eclair", 262, 16.0, 24, 6.0),
+  createData("Cupcake", 305, 3.7, 67, 4.3),
+  createData("Gingerbread", 356, 16.0, 49, 3.9),
+];
+
+export default function GroupsScreen() {
+  const teamId = window.location.pathname.split("/")[2];
+
+  const { user } = useContext(UserContext);
+
+  const [team, setTeam] = React.useState([]);
+
+  useEffect(() => {
+    async function fetchTeam() {
+      try {
+        const response = await fetch("http://localhost:3001/teams/" + teamId, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            "x-access-token": user?.token,
+          },
+        });
+        const data = await response.json();
+        setTeam(data.team ?? {});
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    fetchTeam();
+  }, [user]);
+
+  const [groups, setGroups] = React.useState([]);
+
+  useEffect(() => {
+    async function fetchGroupsOfTeam() {
+      try {
+        const response = await fetch(
+          "http://localhost:3001/teams/" + teamId + "/groups",
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+              "x-access-token": user?.token,
+            },
+          }
+        );
+        const data = await response.json();
+        setGroups(data.groups ?? []);
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    fetchGroupsOfTeam();
+  }, [user]);
+
+  return (
+    <>
+      <Navbar />
+      <Typography
+        variant="h6"
+        sx={{
+          height: "54px",
+          m: "auto 20px",
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        {team.name && team.university
+          ? team.name + " - " + team.university
+          : ""}
+      </Typography>
+      <Divider />
+      <Stack spacing={2} direction="row" sx={{ m: "20px" }}>
+        <Button variant="contained" color="primary" className="page-button">
+          <Link className="button-link" to={`/team/${teamId}/groups`}>
+            Groups
+          </Link>
+        </Button>
+        <Button variant="contained" color="primary" className="page-button">
+          <Link className="button-link" to={`/team/${teamId}/members`}>
+            Members
+          </Link>
+        </Button>
+      </Stack>
+      <Box sx={{ m: "20px" }}>
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>
+                  <Typography variant="h6">Groups</Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="h6">Progress</Typography>
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {groups.map((group) => (
+                <TableRow key={group.id}>
+                  <TableCell component="th" scope="row">
+                    <Link
+                      className="button-link"
+                      to={`/team/${teamId}/group/${group.id}`}
+                    >
+                      <Typography variant="body1">{group.name}</Typography>
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body1">
+                      [////////-----------------------] 10 / 30 [PLACEHOLDER]
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </>
+  );
+}

--- a/upsolver-ui/src/components/MembersScreen/MembersScreen.jsx
+++ b/upsolver-ui/src/components/MembersScreen/MembersScreen.jsx
@@ -1,0 +1,137 @@
+import React from "react";
+import "./MembersScreen.css";
+import Navbar from "../Navbar/Navbar";
+import { Box, Divider, Typography } from "@mui/material";
+import { Button, Stack, Avatar } from "@mui/material";
+import { Link } from "react-router-dom";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from "@mui/material";
+import { UserContext } from "../../UserContext.js";
+import { useEffect, useContext } from "react";
+
+export default function MembersScreen() {
+  const { user } = useContext(UserContext);
+
+  const teamId = window.location.pathname.split("/")[2];
+
+  const [team, setTeam] = React.useState([]);
+
+  useEffect(() => {
+    async function fetchTeam() {
+      try {
+        const response = await fetch("http://localhost:3001/teams/" + teamId, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            "x-access-token": user?.token,
+          },
+        });
+        const data = await response.json();
+        setTeam(data.team ?? {});
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    fetchTeam();
+  }, [user]);
+
+  const [members, setMembers] = React.useState([]);
+
+  useEffect(() => {
+    async function fetchMembersOfTeam() {
+      try {
+        const response = await fetch(
+          "http://localhost:3001/teams/" + teamId + "/users",
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+              "x-access-token": user?.token,
+            },
+          }
+        );
+        const members = await response.json();
+        setMembers(members);
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    fetchMembersOfTeam();
+  }, [user]);
+
+  return (
+    <>
+      <Navbar />
+      <Typography
+        variant="h6"
+        sx={{
+          height: "54px",
+          m: "auto 20px",
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        {team.name && team.university
+          ? team.name + " - " + team.university
+          : ""}
+      </Typography>
+      <Divider />
+      <Stack spacing={2} direction="row" sx={{ m: "20px" }}>
+        <Button variant="contained" color="primary" className="page-button">
+          <Link className="button-link" to={`/team/${teamId}/groups`}>
+            Groups
+          </Link>
+        </Button>
+        <Button variant="contained" color="primary" className="page-button">
+          <Link className="button-link" to={`/team/${teamId}/members`}>
+            Members
+          </Link>
+        </Button>
+      </Stack>
+      <Box sx={{ m: "20px" }}>
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>
+                  <Typography variant="h6">Members</Typography>
+                </TableCell>
+                <TableCell></TableCell>
+                <TableCell></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {members.map((user) => (
+                <TableRow key={user.id}>
+                  <TableCell>
+                    <Avatar variant="square" sx={{ width: 100, height: 100 }}>
+                      {user.name[0]}
+                    </Avatar>
+                  </TableCell>
+                  <TableCell>
+                    <Box sx={{ display: "flex", flexDirection: "column" }}>
+                      <Typography variant="h6">{user.name}</Typography>
+                      <Typography variant="subtitle1">
+                        {user.username}
+                      </Typography>
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="h6">{user.role}</Typography>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </>
+  );
+}

--- a/upsolver-ui/src/components/TeamCard/TeamCard.jsx
+++ b/upsolver-ui/src/components/TeamCard/TeamCard.jsx
@@ -14,7 +14,7 @@ export default function TeamCard({ team }) {
     <Card className="team-card">
       <CardActionArea>
         <Link
-          to={`/team/${team.id}`}
+          to={`/team/${team.id}/groups`}
           style={{
             textDecoration: "none",
             color: "inherit",


### PR DESCRIPTION
## Description

- Create components for team's groups screens, and for team's members. Also added routes for these screens in App.

## Milestones
- Info display.

## Resources
- N/A.

## Test Plan
- The information in the database is displayed correctly: 
<img width="1728" alt="Captura de pantalla 2023-07-13 a la(s) 10 12 41 p m" src="https://github.com/cdamezcua/Upsolver/assets/88699709/2fca30f6-371e-4c27-a449-d4cc38c5aa4b">
<img width="1728" alt="Captura de pantalla 2023-07-13 a la(s) 10 13 01 p m" src="https://github.com/cdamezcua/Upsolver/assets/88699709/0de430da-1210-4b2b-891b-bf83e5aab3c3">

