### PR TITLE
More inviter's information is displayed on incoming invitations

### DIFF
--- a/upsolver-api/routes/invitations.js
+++ b/upsolver-api/routes/invitations.js
@@ -14,7 +14,10 @@ router.get(
     const getInvitations = `
         SELECT
             I.id AS id
-            ,U.username AS inviter
+            ,U.username AS inviterUsername
+            ,U.name AS inviterName
+            ,U.rank AS inviterRank
+            ,U.avatar AS inviterAvatar
             ,T.name AS team
             ,I.role AS role
             ,I.createdAt AS createdAt
@@ -31,7 +34,7 @@ router.get(
     `;
     const invitations = await sequelize.query(getInvitations, {
       type: sequelize.QueryTypes.SELECT,
-    });
+    }) || [];
     res.status(200).json({ invitations });
   })
 );

--- a/upsolver-ui/src/components/InboxScreen/InboxScreen.jsx
+++ b/upsolver-ui/src/components/InboxScreen/InboxScreen.jsx
@@ -17,6 +17,7 @@ import { UserContext } from "../../UserContext.js";
 import { useEffect, useContext } from "react";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import Subtitle from "../Subtitle/Subtitle";
+import { RANKING_COLORS } from "../../constants/config.js";
 
 export default function InvoxScreen() {
   const { user } = useContext(UserContext);
@@ -84,9 +85,7 @@ export default function InvoxScreen() {
   return (
     <>
       <Navbar />
-      <Subtitle>
-        Inbox
-      </Subtitle>
+      <Subtitle>Inbox</Subtitle>
       <Box sx={{ m: "20px" }}>
         <TableContainer component={Paper}>
           <Box
@@ -116,11 +115,33 @@ export default function InvoxScreen() {
             <TableBody>
               {invitations.map((invitation) => (
                 <TableRow key={invitation.id}>
-                  <TableCell>{invitation.inviter}</TableCell>
-                  <TableCell>{invitation.team}</TableCell>
-                  <TableCell>{invitation.role}</TableCell>
                   <TableCell>
-                    {new Date(invitation.createdAt).toLocaleDateString()}
+                    <Stack direction="row" spacing="16px" alignItems="center">
+                      <Avatar
+                        src={invitation.inviterAvatar}
+                        variant="square"
+                        sx={{ width: 50, height: 50 }}
+                      />
+                      <Box sx={{ display: "flex", flexDirection: "column" }}>
+                        <Typography variant="body1" noWrap>
+                          {invitation.inviterName}
+                        </Typography>
+                        <Typography noWrap variant="subtitle2" color={RANKING_COLORS[invitation.inviterRank]}>
+                          {invitation.inviterUsername}
+                        </Typography>
+                      </Box>
+                    </Stack>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body1">{invitation.team}</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body1">{invitation.role}</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body1">
+                      {new Date(invitation.createdAt).toLocaleDateString()}
+                    </Typography>
                   </TableCell>
                   <TableCell>
                     <Stack direction="row" spacing={2}>


### PR DESCRIPTION
## Description

- I modified the object that the GET /users/:userId/invitations responds to include name, rank and avatar.
- I used this new information received to display in the incoming invitations the information of the sender of the invitation.

## Milestones
- External API integration.

## Resources
- N/A.

## Test Plan
- The invitations correctly show the information of the sender:  <img width="1206" alt="Captura de pantalla 2023-07-17 a la(s) 7 02 08 a m" src="https://github.com/cdamezcua/Upsolver/assets/88699709/8178a4d3-11cf-40bc-936f-5964f32902b6">
