### PR TITLE
Loading state for some components and display of users progress on team groups

### DIFF
--- a/upsolver-api/routes/README.md
+++ b/upsolver-api/routes/README.md
@@ -48,3 +48,8 @@ PUT     /teams/:teamId/groups/:groupId/submissions?userId=&problemId=
 
 GET     /teams/:teamId/problems/:problemId/messages
 POST    /teams/:teamId/problems/:problemId/messages
+
+## Progresses
+
+GET     /teams/:teamId/groups/:groupId/progresses?membership=
+GET     /teams/:teamId/progresses?membership=

--- a/upsolver-api/routes/index.js
+++ b/upsolver-api/routes/index.js
@@ -7,9 +7,11 @@ import contestsRoutes from "./contests.js";
 import problemsRoutes from "./problems.js";
 import submissionssRoutes from "./submissions.js";
 import messagesRoutes from "./messages.js";
+import progressesRoutes from "./progresses.js";
 
 const router = express.Router();
 
+router.use("/teams", progressesRoutes);
 router.use("/teams", messagesRoutes);
 router.use("/teams", submissionssRoutes);
 router.use("/teams", problemsRoutes);

--- a/upsolver-api/routes/progresses.js
+++ b/upsolver-api/routes/progresses.js
@@ -1,0 +1,81 @@
+import express from "express";
+import verifyToken from "../middleware/auth.js";
+import { sequelize } from "../database.js";
+import errorHandler from "../middleware/errorHandler.js";
+import tryCatch from "../utils/tryCatch.js";
+import verifyTeamMembership from "../middleware/verifyTeamMembership.js";
+
+const router = express.Router();
+
+router.get(
+  "/:teamId/groups/:groupId/progresses",
+  verifyToken,
+  verifyTeamMembership,
+  tryCatch(async (req, res) => {
+    const { groupId } = req.params;
+    const { membership } = req.query;
+    const problemsOfGroup = `
+        SELECT
+            P.id AS problemId
+        FROM
+            problems P
+            INNER JOIN contests C
+                ON P.contestId = C.id
+            INNER JOIN groups G
+                ON C.groupId = G.id
+        WHERE
+            G.id = ${groupId}
+    `;
+    const membersOfGroup = `
+        SELECT
+            U.id AS userId
+        FROM
+            users U
+            INNER JOIN roles R
+                ON R.userId = U.id
+            INNER JOIN teams T
+                ON T.id = R.teamId
+            INNER JOIN groups G
+                ON G.teamId = T.id
+        WHERE
+            G.id = ${groupId}
+            AND (R.name = '${membership}' 
+                OR '${membership}' = 'undefined')
+    `;
+    const getProgresses = `
+        SELECT
+            U.id AS userId
+            ,count(P.id) AS numberOfProblemsOfGroup
+            ,count(
+                CASE
+                    WHEN S.veredict = 'AC' THEN 1
+                        ELSE NULL
+                END) AS numberOfSolvedProblems
+            ,100 * count(
+                CASE
+                    WHEN S.veredict = 'AC' THEN 1
+                        ELSE NULL
+                END) / count(P.id) AS progress
+        FROM
+            users U
+            CROSS JOIN problems P
+            LEFT JOIN submissions S
+                ON S.userId = U.id
+                AND S.problemId = P.id
+        WHERE
+            U.id IN (${membersOfGroup})
+            AND P.id IN (${problemsOfGroup})
+        GROUP BY
+            U.id;
+    `;
+
+    const progresses = await sequelize.query(getProgresses, {
+      type: sequelize.QueryTypes.SELECT,
+    });
+    res.status(200).json({ progresses });
+  })
+);
+
+router.use(errorHandler);
+
+export default router;

--- a/upsolver-api/routes/progresses.js
+++ b/upsolver-api/routes/progresses.js
@@ -76,6 +76,79 @@ router.get(
   })
 );
 
+router.get(
+  "/:teamId/progresses",
+  verifyToken,
+  verifyTeamMembership,
+  tryCatch(async (req, res) => {
+    const { membership } = req.query;
+    const problemsOfTeam = `
+        SELECT
+            P.id AS problemId
+        FROM
+            problems P
+            INNER JOIN contests C
+                ON P.contestId = C.id
+            INNER JOIN groups G
+                ON C.groupId = G.id
+            INNER JOIN teams T
+                ON G.teamId = T.id
+        WHERE
+            T.id = ${req.params.teamId}
+    `;
+    const membersOfTeam = `
+        SELECT  
+            U.id AS userId
+        FROM
+            users U
+            INNER JOIN roles R
+                ON R.userId = U.id
+            INNER JOIN teams T
+                ON T.id = R.teamId
+        WHERE
+            T.id = ${req.params.teamId}
+            AND (R.name = '${membership}'
+                OR '${membership}' = 'undefined')
+    `;
+    const getProgressesForAllGroupsOfTeam = `
+        SELECT
+            U.id AS userId
+            ,G.id AS groupId
+            ,count(P.id) AS numberOfProblemsOfTeam
+            ,count(
+                CASE
+                    WHEN S.veredict = 'AC' THEN 1
+                        ELSE NULL
+                END) AS numberOfSolvedProblems
+            ,100 * count(
+                CASE
+                    WHEN S.veredict = 'AC' THEN 1
+                        ELSE NULL
+                END) / count(P.id) AS progress
+        FROM
+            users U
+            CROSS JOIN problems P
+            INNER JOIN contests C
+                ON P.contestId = C.id
+            INNER JOIN groups G
+                ON C.groupId = G.id
+            LEFT JOIN submissions S
+                ON S.userId = U.id
+                AND S.problemId = P.id
+        WHERE
+            U.id IN (${membersOfTeam})
+            AND P.id IN (${problemsOfTeam})
+        GROUP BY
+            U.id
+            ,G.id;
+    `;
+    const progresses = await sequelize.query(getProgressesForAllGroupsOfTeam, {
+      type: sequelize.QueryTypes.SELECT,
+    });
+    res.status(200).json({ progresses });
+  })
+);
+
 router.use(errorHandler);
 
 export default router;

--- a/upsolver-ui/package-lock.json
+++ b/upsolver-ui/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.11.0",
         "@fontsource/roboto": "^5.0.4",
         "@mui/icons-material": "^5.13.7",
+        "@mui/lab": "^5.0.0-alpha.137",
         "@mui/material": "^5.13.7",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
@@ -3332,6 +3333,84 @@
         }
       }
     },
+    "node_modules/@mui/lab": {
+      "version": "5.0.0-alpha.137",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.137.tgz",
+      "integrity": "sha512-bHfcfti9/GnB657QpTdlK1fc9gjkP3SC+NrXyb9NCr0rT5Cq7TEkBGXyY5wGUSCyHR3CrMvchkIsfG5sH/NJ9A==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.6",
+        "@mui/base": "5.0.0-beta.8",
+        "@mui/system": "^5.14.1",
+        "@mui/types": "^7.2.4",
+        "@mui/utils": "^5.14.1",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab/node_modules/@mui/base": {
+      "version": "5.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.8.tgz",
+      "integrity": "sha512-b4vVjMZx5KzzEMf4arXKoeV5ZegAMOoPwoy1vfUBwhvXc2QtaaAyBp50U7OA2L06Leubc1A+lEp3eqwZoFn87g==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.6",
+        "@emotion/is-prop-valid": "^1.2.1",
+        "@mui/types": "^7.2.4",
+        "@mui/utils": "^5.14.1",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/@mui/material": {
       "version": "5.13.7",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.13.7.tgz",
@@ -3439,15 +3518,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.13.7",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.13.7.tgz",
-      "integrity": "sha512-7R2KdI6vr8KtnauEfg9e9xQmPk6Gg/1vGNiALYyhSI+cYztxN6WmlSqGX4bjWn/Sygp1TUE1jhFEgs7MWruhkQ==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.1.tgz",
+      "integrity": "sha512-u+xlsU34Jdkgx1CxmBnIC4Y08uPdVX5iEd3S/1dggDFtOGp+Lj8xmKRJAQ8PJOOJLOh8pDwaZx4AwXikL4l1QA==",
       "dependencies": {
-        "@babel/runtime": "^7.22.5",
+        "@babel/runtime": "^7.22.6",
         "@mui/private-theming": "^5.13.7",
         "@mui/styled-engine": "^5.13.2",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.13.7",
+        "@mui/utils": "^5.14.1",
         "clsx": "^1.2.1",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
@@ -3491,11 +3570,11 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.13.7",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.13.7.tgz",
-      "integrity": "sha512-/3BLptG/q0u36eYED7Nhf4fKXmcKb6LjjT7ZMwhZIZSdSxVqDqSTmATW3a56n3KEPQUXCU9TpxAfCBQhs6brVA==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.1.tgz",
+      "integrity": "sha512-39KHKK2JeqRmuUcLDLwM+c2XfVC136C5/yUyQXmO2PVbOb2Bol4KxtkssEqCbTwg87PSCG3f1Tb0keRsK7cVGw==",
       "dependencies": {
-        "@babel/runtime": "^7.22.5",
+        "@babel/runtime": "^7.22.6",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^18.2.1",
         "prop-types": "^15.8.1",

--- a/upsolver-ui/package.json
+++ b/upsolver-ui/package.json
@@ -7,6 +7,7 @@
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.4",
     "@mui/icons-material": "^5.13.7",
+    "@mui/lab": "^5.0.0-alpha.137",
     "@mui/material": "^5.13.7",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/upsolver-ui/src/components/ProblemsTableScreen/ProblemsTableScreen.jsx
+++ b/upsolver-ui/src/components/ProblemsTableScreen/ProblemsTableScreen.jsx
@@ -27,8 +27,10 @@ import AddIcon from "@mui/icons-material/Add";
 import { DIVISION_COLORS } from "../../constants/config";
 import ForumIcon from "@mui/icons-material/Forum";
 import ChatDialog from "../ChatDialog/ChatDialog";
+import ProblemsTableSkeleton from "../ProblemsTableSkeleton/ProblemsTableSkeleton";
 
 export default function ProblemsTableScreen() {
+  const [loading, setLoading] = React.useState(true);
   const { user } = useContext(UserContext);
   const teamId = window.location.pathname.split("/")[2];
   const groupId = window.location.pathname.split("/")[4];
@@ -96,6 +98,7 @@ export default function ProblemsTableScreen() {
         );
         const data = await response.json();
         setContestsProblems(data.contestsProblems ?? []);
+        setLoading(false);
       } catch (error) {
         console.log(error);
       }
@@ -191,174 +194,184 @@ export default function ProblemsTableScreen() {
           </Button>
         </Stack>
       </Stack>
-      <Box sx={{ m: "20px" }}>
-        <TableContainer component={Paper}>
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              m: "20px",
-            }}
-          >
-            <Typography variant="h6">{group.name ? group.name : ""}</Typography>
-            <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
-              <Fab
-                variant="extended"
-                size="medium"
-                color="primary"
-                aria-label="add"
-                onClick={() => {}}
-              >
-                <AddIcon sx={{ mr: 1 }} />
-                Add Contest
-              </Fab>
-            </Stack>
-          </Box>
-          <Divider />
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Contest Division</TableCell>
-                <TableCell>Contest Number</TableCell>
-                <TableCell>Contest Name</TableCell>
-                <TableCell>Problem Number</TableCell>
-                <TableCell>Problem Name</TableCell>
-                {contestants.map((contestant) => (
-                  <TableCell
-                    key={contestant.id}
-                    sx={{ width: "100px", textAlign: "center" }}
-                  >
-                    {contestant.username}
-                  </TableCell>
-                ))}
-                <TableCell>Problem Solved Count</TableCell>
-                <TableCell>Chat</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {contestsProblems.map((contestProblem) => (
-                <TableRow key={contestProblem.problemId}>
-                  <TableCell>
-                    <Chip
-                      color={DIVISION_COLORS[contestProblem.contestDivision]}
-                      label={contestProblem.contestDivision}
-                    />
-                  </TableCell>
-                  <TableCell>{contestProblem.contestNumber}</TableCell>
-                  <TableCell>
-                    <Link to={contestProblem.contestURL}>
-                      {contestProblem.contestName}
-                    </Link>
-                  </TableCell>
-                  <TableCell>{contestProblem.problemNumber}</TableCell>
-                  <TableCell>
-                    <Link to={contestProblem.problemURL}>
-                      {contestProblem.problemName}
-                    </Link>
-                  </TableCell>
+      {loading ? (
+        <ProblemsTableSkeleton />
+      ) : (
+        <Box sx={{ m: "20px" }}>
+          <TableContainer component={Paper}>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                m: "20px",
+              }}
+            >
+              <Typography variant="h6">
+                {group.name ? group.name : ""}
+              </Typography>
+              <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+                <Fab
+                  variant="extended"
+                  size="medium"
+                  color="primary"
+                  aria-label="add"
+                  onClick={() => {}}
+                >
+                  <AddIcon sx={{ mr: 1 }} />
+                  Add Contest
+                </Fab>
+              </Stack>
+            </Box>
+            <Divider />
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Contest Division</TableCell>
+                  <TableCell>Contest Number</TableCell>
+                  <TableCell>Contest Name</TableCell>
+                  <TableCell>Problem Number</TableCell>
+                  <TableCell>Problem Name</TableCell>
                   {contestants.map((contestant) => (
-                    <TableCell key={contestProblem.problemId + contestant.id}>
-                      {submissions
-                        .filter(
-                          (submission) =>
-                            submission.problemId === contestProblem.problemId &&
-                            submission.userId === contestant.id
-                        )
-                        .map((submission) => (
-                          <FormControl
-                            fullWidth
-                            key={submission.userId + "-" + submission.problemId}
-                            size="small"
-                          >
-                            <Select
-                              sx={{
-                                textAlign: "center",
-                                backgroundColor:
-                                  submission.veredict === "AC"
-                                    ? "#4caf50"
-                                    : submission.veredict === "WA"
-                                    ? "#f44336"
-                                    : submission.veredict === "TLE"
-                                    ? "#ff9800"
-                                    : "inherit",
-                              }}
-                              defaultValue={""}
-                              value={submission.veredict ?? ""}
-                              onChange={(event) => {
-                                setSubmissions(
-                                  submissions.map((submission) => {
-                                    if (
-                                      submission.problemId ===
-                                        contestProblem.problemId &&
-                                      submission.userId === contestant.id
-                                    ) {
-                                      submission.veredict = event.target.value;
-                                    }
-                                    return submission;
-                                  })
-                                );
-                                async function updateVeredict() {
-                                  try {
-                                    const response = await fetch(
-                                      "http://localhost:3001/teams/" +
-                                        teamId +
-                                        "/groups/" +
-                                        groupId +
-                                        "/submissions/" +
-                                        "?userId=" +
-                                        contestant.id +
-                                        "&problemId=" +
-                                        contestProblem.problemId,
-                                      {
-                                        method: "PATCH",
-                                        headers: {
-                                          "Content-Type": "application/json",
-                                          "x-access-token": user?.token,
-                                        },
-                                        body: JSON.stringify({
-                                          veredict: event.target.value,
-                                        }),
-                                      }
-                                    );
-                                    const data = await response.json();
-                                    console.log(data);
-                                  } catch (error) {
-                                    console.log(error);
-                                  }
-                                }
-                                updateVeredict();
-                              }}
-                            >
-                              <MenuItem value={""}>
-                                <em>None</em>
-                              </MenuItem>
-                              <MenuItem value={"AC"}>AC</MenuItem>
-                              <MenuItem value={"WA"}>WA</MenuItem>
-                              <MenuItem value={"TLE"}>TLE</MenuItem>
-                            </Select>
-                          </FormControl>
-                        ))}
+                    <TableCell
+                      key={contestant.id}
+                      sx={{ width: "100px", textAlign: "center" }}
+                    >
+                      {contestant.username}
                     </TableCell>
                   ))}
-                  <TableCell>{contestProblem.problemSolvedCount}</TableCell>
-                  <TableCell>
-                    <IconButton
-                      color="primary"
-                      onClick={() => {
-                        setActiveContestProblem(contestProblem);
-                        setIsChatOpen(true);
-                      }}
-                    >
-                      <ForumIcon />
-                    </IconButton>
-                  </TableCell>
+                  <TableCell>Problem Solved Count</TableCell>
+                  <TableCell>Chat</TableCell>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Box>
+              </TableHead>
+              <TableBody>
+                {contestsProblems.map((contestProblem) => (
+                  <TableRow key={contestProblem.problemId}>
+                    <TableCell>
+                      <Chip
+                        color={DIVISION_COLORS[contestProblem.contestDivision]}
+                        label={contestProblem.contestDivision}
+                      />
+                    </TableCell>
+                    <TableCell>{contestProblem.contestNumber}</TableCell>
+                    <TableCell>
+                      <Link to={contestProblem.contestURL}>
+                        {contestProblem.contestName}
+                      </Link>
+                    </TableCell>
+                    <TableCell>{contestProblem.problemNumber}</TableCell>
+                    <TableCell>
+                      <Link to={contestProblem.problemURL}>
+                        {contestProblem.problemName}
+                      </Link>
+                    </TableCell>
+                    {contestants.map((contestant) => (
+                      <TableCell key={contestProblem.problemId + contestant.id}>
+                        {submissions
+                          .filter(
+                            (submission) =>
+                              submission.problemId ===
+                                contestProblem.problemId &&
+                              submission.userId === contestant.id
+                          )
+                          .map((submission) => (
+                            <FormControl
+                              fullWidth
+                              key={
+                                submission.userId + "-" + submission.problemId
+                              }
+                              size="small"
+                            >
+                              <Select
+                                sx={{
+                                  textAlign: "center",
+                                  backgroundColor:
+                                    submission.veredict === "AC"
+                                      ? "#4caf50"
+                                      : submission.veredict === "WA"
+                                      ? "#f44336"
+                                      : submission.veredict === "TLE"
+                                      ? "#ff9800"
+                                      : "inherit",
+                                }}
+                                defaultValue={""}
+                                value={submission.veredict ?? ""}
+                                onChange={(event) => {
+                                  setSubmissions(
+                                    submissions.map((submission) => {
+                                      if (
+                                        submission.problemId ===
+                                          contestProblem.problemId &&
+                                        submission.userId === contestant.id
+                                      ) {
+                                        submission.veredict =
+                                          event.target.value;
+                                      }
+                                      return submission;
+                                    })
+                                  );
+                                  async function updateVeredict() {
+                                    try {
+                                      const response = await fetch(
+                                        "http://localhost:3001/teams/" +
+                                          teamId +
+                                          "/groups/" +
+                                          groupId +
+                                          "/submissions/" +
+                                          "?userId=" +
+                                          contestant.id +
+                                          "&problemId=" +
+                                          contestProblem.problemId,
+                                        {
+                                          method: "PATCH",
+                                          headers: {
+                                            "Content-Type": "application/json",
+                                            "x-access-token": user?.token,
+                                          },
+                                          body: JSON.stringify({
+                                            veredict: event.target.value,
+                                          }),
+                                        }
+                                      );
+                                      const data = await response.json();
+                                      console.log(data);
+                                    } catch (error) {
+                                      console.log(error);
+                                    }
+                                  }
+                                  updateVeredict();
+                                }}
+                              >
+                                <MenuItem value={""}>
+                                  <em>None</em>
+                                </MenuItem>
+                                <MenuItem value={"AC"}>AC</MenuItem>
+                                <MenuItem value={"WA"}>WA</MenuItem>
+                                <MenuItem value={"TLE"}>TLE</MenuItem>
+                              </Select>
+                            </FormControl>
+                          ))}
+                      </TableCell>
+                    ))}
+                    <TableCell>{contestProblem.problemSolvedCount}</TableCell>
+                    <TableCell>
+                      <IconButton
+                        color="primary"
+                        onClick={() => {
+                          setActiveContestProblem(contestProblem);
+                          setIsChatOpen(true);
+                        }}
+                      >
+                        <ForumIcon />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Box>
+      )}
       <ChatDialog
         isChatOpen={isChatOpen}
         setIsChatOpen={setIsChatOpen}

--- a/upsolver-ui/src/components/ProblemsTableSkeleton/ProblemsTableSkeleton.jsx
+++ b/upsolver-ui/src/components/ProblemsTableSkeleton/ProblemsTableSkeleton.jsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { Box, Chip, Skeleton, Typography } from "@mui/material";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Divider,
+  Fab,
+  Stack,
+  Select,
+  IconButton,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import ForumIcon from "@mui/icons-material/Forum";
+
+export default function ProblemsTableSkeleton() {
+  return (
+    <Box sx={{ m: "20px" }}>
+      <TableContainer component={Paper}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            m: "20px",
+          }}
+        >
+          <Skeleton>
+            <Typography variant="h6">Training Camp México 2023</Typography>
+          </Skeleton>
+          <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+            <Skeleton>
+              <Fab
+                variant="extended"
+                size="medium"
+                color="primary"
+                aria-label="add"
+                onClick={() => {}}
+              >
+                <AddIcon sx={{ mr: 1 }} />
+                Add Contest
+              </Fab>
+            </Skeleton>
+          </Stack>
+        </Box>
+        <Divider />
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>
+                <Skeleton />
+              </TableCell>
+              <TableCell>
+                <Skeleton />
+              </TableCell>
+              <TableCell>
+                <Skeleton />
+              </TableCell>
+              <TableCell>
+                <Skeleton />
+              </TableCell>
+              <TableCell>
+                <Skeleton />
+              </TableCell>
+              <TableCell>
+                <Skeleton />
+              </TableCell>
+              <TableCell>
+                <Skeleton />
+              </TableCell>
+              <TableCell>
+                <Skeleton />
+              </TableCell>
+              <TableCell>
+                <Skeleton />
+              </TableCell>
+              <TableCell>
+                <Skeleton />
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {Array.from(new Array(10)).map((_, index) => (
+              <TableRow>
+                <TableCell>
+                  <Skeleton>
+                    <Chip label="DivX" />
+                  </Skeleton>
+                </TableCell>
+                <TableCell>
+                  <Skeleton />
+                </TableCell>
+                <TableCell>
+                  <Skeleton />
+                </TableCell>
+                <TableCell>
+                  <Skeleton />
+                </TableCell>
+                <TableCell>
+                  <Skeleton />
+                </TableCell>
+                <TableCell>
+                  <Skeleton>
+                    <Select value="" />
+                  </Skeleton>
+                </TableCell>
+                <TableCell>
+                  <Skeleton>
+                    <Select value="" />
+                  </Skeleton>
+                </TableCell>
+                <TableCell>
+                  <Skeleton>
+                    <Select value="" />
+                  </Skeleton>
+                </TableCell>
+                <TableCell>
+                  <Skeleton />
+                </TableCell>
+                <TableCell>
+                  <Skeleton>
+                    <IconButton>
+                      <ForumIcon />
+                    </IconButton>
+                  </Skeleton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Description
In this pull request I work to fulfill the requirement of having load states in the interface. Now, while creating a team, the create team button is disabled and a spinner appears. Also, when entering to see a group, while the problem table is loaded, a skeleton of it is shown.

Additionally I show the progress of the competitors in the group list.

## Milestones
- Contestants progress visualization
- Loading states

## Resources
- N/A.

## Test Plan
In this video where a team is created you can see the new features working:

https://github.com/cdamezcua/Upsolver/assets/88699709/52e94fe1-630b-4b40-a9db-2da37be147a0


